### PR TITLE
Feature : tap blank space to close the menu

### DIFF
--- a/asset/js/thedaily.js
+++ b/asset/js/thedaily.js
@@ -28,7 +28,6 @@
 
         $('header').click(function(e){
             $target = $(e.target);
-            console.log($target)
             if ($target.is("header")) {
                 // close both
                 // close search

--- a/asset/js/thedaily.js
+++ b/asset/js/thedaily.js
@@ -42,7 +42,7 @@
                     $('body').removeClass('menu-open');
                 }
             }
-            if ($target.is( ".navigation" )) {
+            if ($target.is( "#top-nav ul, #top-nav li" )) {
                 // close navigation
                 if ($('body').hasClass('menu-open')) {
                     $('#top-nav').toggleClass('open').toggleClass('closed');

--- a/asset/js/thedaily.js
+++ b/asset/js/thedaily.js
@@ -25,5 +25,38 @@
                 $('.search-toggle').focus();
             }
         });
+
+        $('header').click(function(e){
+            $target = $(e.target);
+            console.log($target)
+            if ($target.is("header")) {
+                // close both
+                // close search
+                if ($('body').hasClass('search-open')) {
+                    $('#search-form.open').toggleClass('open').toggleClass('closed');
+                    $('body').removeClass('search-open');
+                }
+
+                // close navigation
+                if ($('body').hasClass('menu-open')) {
+                    $('#top-nav').toggleClass('open').toggleClass('closed');
+                    $('body').removeClass('menu-open');
+                }
+            }
+            if ($target.is( ".navigation" )) {
+                // close navigation
+                if ($('body').hasClass('menu-open')) {
+                    $('#top-nav').toggleClass('open').toggleClass('closed');
+                    $('body').removeClass('menu-open');
+                }
+            }
+            if ($target.is("#search-form")) {
+                // close search
+                if ($('body').hasClass('search-open')) {
+                    $('#search-form.open').toggleClass('open').toggleClass('closed');
+                    $('body').removeClass('search-open');
+                }
+            }
+        });
     });
 })(jQuery)


### PR DESCRIPTION
Hello,

I'm suggesting an addition to how Navigation and Search menus are closed.

A click/tap on any section of the header that is blank should now close the active menu.

It is a nice to have feature on mobile, but it is really a must have for larger displays where it is often required to travel across the whole screen in order to close the navigation or the search form.

Code could be refactored but I kept it simple for readability.

Thanks and have a nice day

Laurent